### PR TITLE
Force faraday to 1.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in nordigen.gemspec
 gemspec
 
-gem "faraday", "~> 2.5"
+gem "faraday", "~> 1.10"
 
 group :development do
   gem "rake", "~> 13.0"

--- a/nordigen.gemspec
+++ b/nordigen.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n")
                       .map { |f| ::File.basename(f) }
 
-  spec.add_dependency "faraday", "~> 2.5"
+  spec.add_dependency "faraday", "~> 1.10"
 
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
https://outfund.atlassian.net/browse/DEV-2616

## Related Issue
There is a dependency conflict with the faraday gem in Core App when trying to add [Nordigen Ruby gem](https://github.com/nordigen/nordigen-ruby).

```
➜  core-app git:(main) ✗ bundle install
Fetching gem metadata from https://rubygems.pkg.github.com/out-fund/...
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies......
Bundler could not find compatible versions for gem "faraday":
  In snapshot (Gemfile.lock):
    faraday (= 1.10.2)

  In Gemfile:
    facebookbusiness (~> 0.14.0.0) was resolved to 0.14.0.0, which depends on
      faraday (~> 1.0)

    google-ads-googleads was resolved to 19.0.0, which depends on
      gapic-common (~> 0.6) was resolved to 0.11.1, which depends on
        faraday (>= 1.9, < 3.a)

    gocardless_pro was resolved to 2.34.0, which depends on
      faraday (>= 0.9.2, < 2)

    google-ads-googleads was resolved to 19.0.0, which depends on
      gapic-common (~> 0.6) was resolved to 0.11.1, which depends on
        googleauth (~> 1.0) was resolved to 1.2.0, which depends on
          faraday (>= 0.17.3, < 3.a)

    nordigen-ruby was resolved to 1.0.1, which depends on
      faraday (~> 1.8.0)

    omniauth-google-oauth2 was resolved to 0.8.2, which depends on
      oauth2 (~> 1.1) was resolved to 1.4.11, which depends on
        faraday (>= 0.17.3, < 3.0)

    google-ads-googleads was resolved to 19.0.0, which depends on
      gapic-common (~> 0.6) was resolved to 0.11.1, which depends on
        googleauth (~> 1.0) was resolved to 1.2.0, which depends on
          signet (>= 0.16, < 2.a) was resolved to 0.17.0, which depends on
            faraday (>= 0.17.5, < 3.a)

    xero-ruby was resolved to 3.14.0, which depends on
      faraday (~> 1.0, >= 1.0.1)

Deleting your Gemfile.lock file and running `bundle install` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
➜
```

## Proposed Changes
This PR aims to fork the code from the author and reference our github repo [directly from Core App](https://github.com/out-fund/core-app/pull/4343/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR125).

Once we are more certain about whether we want to go ahead using Nordigen, we may try to work out a more long term solution.